### PR TITLE
Remove CodeMirror from createSymLinks function

### DIFF
--- a/app/bin/functions.sh
+++ b/app/bin/functions.sh
@@ -173,7 +173,6 @@ function createSymLinks(){
     cd $__DIR__/../..
     rm -rf  engine/Library
     mkdir -p engine/Library
-    ln -s ../../vendor/shopware/shopware/engine/Library/CodeMirror engine/Library/CodeMirror
     ln -s ../../vendor/shopware/shopware/engine/Library/ExtJs engine/Library/ExtJs
     ln -s ../../vendor/shopware/shopware/engine/Library/TinyMce engine/Library/TinyMce
 


### PR DESCRIPTION
Since you proposed an update to shopware/composer-project with a version bump to Shopware 5.6, I would like to add this change to your pull request. Shopware 5.6 does not come with CodeMirror in the `engine/Library` directory anymore, so you should remove the symlink to it.